### PR TITLE
Add websocket auth in OT

### DIFF
--- a/handler/document.go
+++ b/handler/document.go
@@ -504,7 +504,6 @@ func (h *Handler) getOTHandler(c *gin.Context) {
 		}
 
 		editable = isRelatedUUID(uuid, teams, docInfo.OwnerUUID) || docInfo.Permission == db.FilePermReadWrite
-		authok = true
 	}
 
 	// Prepare OT session


### PR DESCRIPTION
In this PR, new method to auth token is added.
The method uses the token which client sends just after websocket connection.
Please refer the following code for client.
```
diff --git a/components/molecules/document/DocEditor.vue b/components/molecules/document/DocEditor.vue
index 4393924..455cbc0 100644
--- a/components/molecules/document/DocEditor.vue
+++ b/components/molecules/document/DocEditor.vue
@@ -96,13 +96,16 @@ export default Vue.extend({
         process.env.NODE_ENV === 'development'
           ? process.env.DOMAIN
           : location.host
-      const url = `${process.env.WS_SCHEME}://${DOMAIN}${process.env.BASE_PATH}/doc/${this.$route.params.id}/ws?token=${this.$store.getters['auth/token']}`
+      const url = `${process.env.WS_SCHEME}://${DOMAIN}${process.env.BASE_PATH}/doc/${this.$route.params.id}/ws`
       this.websocket = new socket.SocketConnection(url, !this.isEditable)
       this.serverAdapter = new socket.SocketConnectionAdapter(this.websocket)
       this.websocket.on('join', this.joinEvent)
       this.websocket.on('quit', this.quitEvent)
       this.websocket.on('doc', this.docEvent)
       this.websocket.on('close', this.closeEvent)
+      this.websocket.on('open', () => {
+        this.websocket.send('auth', `${this.$store.getters['auth/token']}`)
+      })
     },
     //
     // CodeMirror Event
```

close #133

